### PR TITLE
Adding missing specification for spikes_file and report file_name

### DIFF
--- a/docs/SONATA_DEVELOPER_GUIDE.md
+++ b/docs/SONATA_DEVELOPER_GUIDE.md
@@ -904,13 +904,25 @@ Example:
 
 ### Output Configuration
 
-The "output" block configures the location where output reports should be written, and if output should be overwritten.
+The "output" block configures the location where output reports should be
+written. An optional attribute named "overwrite_output_dir" provides a hint
+to simulators to let them know if already existing output files must be
+overwritten.
 
+The default behaviour is for simulators to produce spike data (a series of
+gid, timestamp pairs). By default the name of the file is "spikes.h5" and it
+is written to <output_dir>. The name of the output file for spikes can be
+configured with the optional attribute "spikes_file" (using a relative or
+absolute path in spikes_file has undefined behaviour)
+
+Example
     "output": {
         "log_file": "$OUTPUT_DIR/log.txt",
         "output_dir": "$OUTPUT_DIR",
         "overwrite_output_dir": true,
+        "spikes_file": "run0.h5",
     },
+
 
 ### Implementation Specific Parameters
 
@@ -1066,7 +1078,9 @@ Example of the corresponding input_file (column names):
 
 ### Simulation output - Reports
 
-The output of the simulation is reported based on the specifications of the output variables described in the simulation configuration file under the "reports" block. Spikes are always reported, and a report specification needn’t be specified to have the simulation report the spikes. Simulators are expected to write spike reports to a file called spikes.h5 (whole file format is explained [below](#spike_file)) located at the output_dir.
+The output of the simulation is reported based on the specifications of the
+output variables described in the simulation configuration file under the
+"reports" block.
 
 There can be one or more reports in the block, each one identified by a unique name:
 
@@ -1082,7 +1096,12 @@ There can be one or more reports in the block, each one identified by a unique n
             }
         }
 
-On simulation launch, a file for each specified report is then created with filename <report_name>.h5
+Simulators are expected to create a file for each specified report under the
+output directory using the file name <report_name>.<ext>, where ext is the
+file extension specific to the report configuration. The file name can be
+overriden with the attribute "file_name".
+
+Some reserved attributes are the following:
 
 <table>
   <tr>
@@ -1155,6 +1174,15 @@ On simulation launch, a file for each specified report is then created with file
     <td>False</td>
     <td>Simulator default</td>
   </tr>
+  <tr>
+    <td>file_name</td>
+    <td>Report file name including extension. Reports are always written to the
+      output directory given in the output configuration block</td>
+    <td>string</td>
+    <td>False</td>
+    <td>-</td>
+  </tr>
+
 </table>
 
 
@@ -1264,7 +1292,9 @@ node_id mapping is specified according to [description below](#gid_mapping).
 
 ### **Output file formats**
 
-Each report name in the "reports" block results in a separate HDF5 file with the filename <report_name>.h5.
+Each report name in the "reports" block results in a separate HDF5 file with
+the filename <report_name>.h5 written to the output directory (unless the user
+provides a different file name).
 
 #### <a name="spike_file"></a>Spike file
 

--- a/examples/300_cells/build_network.py
+++ b/examples/300_cells/build_network.py
@@ -13,27 +13,27 @@ print('Building internal network')
 cell_models = [
     {
         'model_name': 'Scnn1a', 'ei': 'e',
-        'morphology': 'Scnn1a_473845048_m.swc',
+        'morphology': 'Scnn1a_473845048_m',
         'model_template': 'nml:Cell_472363762.cell.nml'
     },
     {
         'model_name': 'Rorb', 'ei': 'e',
-        'morphology': 'Rorb_325404214_m.swc',
+        'morphology': 'Rorb_325404214_m',
         'model_template': 'nml:Cell_473863510.cell.nml'
     },
     {
         'model_name': 'Nr5a1', 'ei': 'e',
-        'morphology': 'Nr5a1_471087815_m.swc',
+        'morphology': 'Nr5a1_471087815_m',
         'model_template': 'nml:Cell_473863035.cell.nml'
     },
     {
         'model_name': 'PV1', 'ei': 'i',
-        'morphology': 'Pvalb_470522102_m.swc',
+        'morphology': 'Pvalb_470522102_m',
         'model_template': 'nml:Cell_472912177.cell.nml'
     },
     {
         'model_name': 'PV2', 'ei': 'i',
-        'morphology': 'Pvalb_469628681_m.swc',
+        'morphology': 'Pvalb_469628681_m',
         'model_template': 'nml:Cell_473862421.cell.nml'
     }
 ]

--- a/examples/9_cells/build_network.py
+++ b/examples/9_cells/build_network.py
@@ -9,17 +9,17 @@ use_nml = True  # True to build network with NEUROML files, false to build netwo
 
 cell_models = [
     {
-        'model_name': 'Scnn1a', 'ei': 'e', 'morphology': 'Scnn1a_473845048_m.swc',
+        'model_name': 'Scnn1a', 'ei': 'e', 'morphology': 'Scnn1a_473845048_m',
         'model_template': 'nml:nml/Cell_472363762.cell.nml' if use_nml else 'ctdb:Biophys1.hoc',
         'dynamics_params': 'NONE' if use_nml else 'json/472363762_fit.json'
     },
     {
-        'model_name': 'Rorb', 'ei': 'e', 'morphology': 'Rorb_325404214_m.swc',
+        'model_name': 'Rorb', 'ei': 'e', 'morphology': 'Rorb_325404214_m',
         'model_template': 'nml:nml/Cell_473863510.cell.nml' if use_nml else 'ctdb:Biophys1.hoc',
         'dynamics_params': 'NONE' if use_nml else 'json/473863510_fit.json'
     },
     {
-        'model_name': 'Nr5a1', 'ei': 'e', 'morphology': 'Nr5a1_471087815_m.swc',
+        'model_name': 'Nr5a1', 'ei': 'e', 'morphology': 'Nr5a1_471087815_m',
         'model_template': 'nml:nml/Cell_473863035.cell.nml' if use_nml else 'ctdb:Biophys1.hoc',
         'dynamics_params': 'NONE' if use_nml else 'json/473863035_fit.json'
     }

--- a/examples/9_cells/network/cortex_node_types.csv
+++ b/examples/9_cells/network/cortex_node_types.csv
@@ -1,4 +1,4 @@
 node_type_id ei morphology model_processing model_template model_type dynamics_params model_name
-100 e Scnn1a_473845048_m.swc aibs_perisomatic nml:nml/Cell_472363762.cell.nml biophysical NONE Scnn1a
-101 e Rorb_325404214_m.swc aibs_perisomatic nml:nml/Cell_473863510.cell.nml biophysical NONE Rorb
-102 e Nr5a1_471087815_m.swc aibs_perisomatic nml:nml/Cell_473863035.cell.nml biophysical NONE Nr5a1
+100 e Scnn1a_473845048_m aibs_perisomatic nml:nml/Cell_472363762.cell.nml biophysical NONE Scnn1a
+101 e Rorb_325404214_m aibs_perisomatic nml:nml/Cell_473863510.cell.nml biophysical NONE Rorb
+102 e Nr5a1_471087815_m aibs_perisomatic nml:nml/Cell_473863035.cell.nml biophysical NONE Nr5a1

--- a/examples/9_cells/simulation_config.json
+++ b/examples/9_cells/simulation_config.json
@@ -47,8 +47,8 @@
   "output":{ 
     "log_file": "$OUTPUT_DIR/log.txt",
     "output_dir": "$OUTPUT_DIR",
-    "spikes_file": "$OUTPUT_DIR/spikes.h5",
-    "spikes_file_csv": "$OUTPUT_DIR/spikes.csv",
+    "spikes_file": "spikes.h5",
+    "spikes_file_csv": "spikes.csv",
     "spikes_sort_order": "time"
   },
 
@@ -57,7 +57,7 @@
       "cells": "biophys_cells",
       "variable_name": "v",
       "module": "membrane_report",
-      "file_name": "$OUTPUT_DIR/cell_vars.h5",
+      "file_name": "cell_vars.h5",
       "sections": "soma"
     },
 
@@ -65,7 +65,7 @@
       "cells": "biophys_cells",
       "variable_name": "cai",
       "module": "membrane_report",
-      "file_name": "$OUTPUT_DIR/cell_vars.h5",
+      "file_name": "cell_vars.h5",
       "sections": "soma"
     }
   }


### PR DESCRIPTION
Note that absolute paths are not allowed. The rational is that if
instead of just filenames, absolute paths are also allowed, then
relative paths should also be allowed and that renders output_dir
pointless and/or ambiguous unless undesirable verbosity is added
to the spec to resolve the ambiguity.

Example simulation config fixed accordingly