### PR TITLE
Fix/issue40

### DIFF
--- a/examples/5_cells_iclamp/simulation_config.json
+++ b/examples/5_cells_iclamp/simulation_config.json
@@ -2,7 +2,8 @@
   "manifest": {
     "$BASE_DIR": ".",
     "$OUTPUT_DIR": "$BASE_DIR/output",
-    "$INPUT_DIR": "$BASE_DIR/inputs"
+    "$INPUT_DIR": "$BASE_DIR/inputs",
+    "$COMPONENT_DIR": "$BASE_DIR/../shared_components"
   },
 
   "run": {

--- a/examples/9_cells/build_network.py
+++ b/examples/9_cells/build_network.py
@@ -36,7 +36,7 @@ for i, model_props in enumerate(cell_models):
 cortex.build()
 cortex.save_nodes(output_dir='network')
 
-morphologies = {p['model_name']: SWCReader(os.path.join('../shared_components/morphologies', p['morphology']))
+morphologies = {p['model_name']: SWCReader(os.path.join('../shared_components/morphologies', '{}.swc'.format(p['morphology'])))
                 for p in cell_models}
 
 

--- a/examples/9_cells/plot_raster.py
+++ b/examples/9_cells/plot_raster.py
@@ -1,0 +1,3 @@
+from bmtk.analyzer.spike_trains import raster_plot
+
+raster_plot('network/cortex_nodes.h5', 'network/cortex_node_types.csv', 'output/spikes.h5')


### PR DESCRIPTION
Issue #40 

For the 5-cell iclamp example simulation_config.json changed $COMPONENT_DIR to $COMPONENT**S**_DIR so the variable can be resolved in the manifest.

For the 9-cells example updated the build script to be able to resolve the full morphology path.