### PR TITLE
Updating documentation to be more explicit in simulation block

### DIFF
--- a/docs/SONATA_DEVELOPER_GUIDE.md
+++ b/docs/SONATA_DEVELOPER_GUIDE.md
@@ -846,7 +846,7 @@ The "run" block specifies some global parameters of the simulation run, such as 
 
 ### Conditions Configuration
 
-This block specifies optional global parameters with reserved meaning associated with manipulation of the "in silico preparation".
+This block specifies optional global parameters with reserved meaning associated with manipulation of the "in silico preparation".dsff 
 
 Example:
 
@@ -1379,4 +1379,3 @@ Allen folks to fill in
 For the case that the model_template follows the *bmtk* schema, the following is the expected structure of the hoc template.
 
 Allen folks to fill in
-


### PR DESCRIPTION
A fix to issue #52 (and #22), explicitly adding the definition of "dL" parameter in the "run" block of the simulation config.

I went a head and added a table for all the attributes in the block.