### PR TITLE
Fixing so that all examples use model_name instead of pop_name

### DIFF
--- a/examples/300_intfire/build_network.py
+++ b/examples/300_intfire/build_network.py
@@ -7,12 +7,12 @@ from bmtk.builder.networks import NetworkBuilder
 # Step 1: Create a v1 mock network of 14 cells (nodes) with across 7 different cell "types"
 net = NetworkBuilder("v1")
 
-net.add_nodes(N=240, pop_name='LIF_exc', location='VisL4', ei='e',
+net.add_nodes(N=240, model_name='LIF_exc', location='VisL4', ei='e',
               model_type='point_process',  # use point_process to indicate were are using point model cells
               model_template='nrn:IntFire1',  # Tell the simulator to use the NEURON built-in IntFire1 type cell
               dynamics_params='IntFire1_exc_1.json')
 
-net.add_nodes(N=60, pop_name='LIF_inh', location='VisL4', ei='i',
+net.add_nodes(N=60, model_name='LIF_inh', location='VisL4', ei='i',
               model_type='point_process',
               model_template='nrn:IntFire1',
               dynamics_params='IntFire1_inh_1.json')
@@ -46,7 +46,7 @@ net.add_edges(source={'ei': 'i'}, target={'ei': 'e', 'model_type': 'point_proces
               dynamics_params='instanteneousInh.json')
 
 
-net.add_edges(source={'ei': 'e'}, target={'pop_name': 'LIF_inh'},
+net.add_edges(source={'ei': 'e'}, target={'model_name': 'LIF_inh'},
               iterator='all_to_one',
               connection_rule=recurrent_connections,
               connection_params={'n_syns': 10},
@@ -56,7 +56,7 @@ net.add_edges(source={'ei': 'e'}, target={'pop_name': 'LIF_inh'},
               dynamics_params='instanteneousExc.json')
 
 
-net.add_edges(source={'ei': 'e'}, target={'pop_name': 'LIF_exc'},
+net.add_edges(source={'ei': 'e'}, target={'model_name': 'LIF_exc'},
               iterator='all_to_one',
               connection_rule=recurrent_connections,
               connection_params={'n_syns': 10},
@@ -78,33 +78,33 @@ def generate_positions(N, x0=0.0, x1=300.0, y0=0.0, y1=100.0):
 
 def select_source_cells(src_cells, trg_cell, n_syns):
     if np.random.random() > 0.1:
-        synapses = [n_syns if src['pop_name'] == 'tON' or src['pop_name'] == 'tOFF' else 0 for src in src_cells]
+        synapses = [n_syns if src['model_name'] == 'tON' or src['model_name'] == 'tOFF' else 0 for src in src_cells]
     else:
-        synapses = [n_syns if src['pop_name'] == 'tONOFF' else 0 for src in src_cells]
+        synapses = [n_syns if src['model_name'] == 'tONOFF' else 0 for src in src_cells]
 
     return synapses
 
 
 lgn = NetworkBuilder("lgn")
 pos_x, pos_y = generate_positions(30)
-lgn.add_nodes(N=30, pop_name='tON', ei='e', location='LGN',
+lgn.add_nodes(N=30, model_name='tON', ei='e', location='LGN',
               x=pos_x, y=pos_y,
               model_type='virtual')
 
 pos_x, pos_y = generate_positions(30)
-lgn.add_nodes(N=30, pop_name='tOFF', ei='e', location='LGN',
+lgn.add_nodes(N=30, model_name='tOFF', ei='e', location='LGN',
               x=pos_x, y=pos_y,
               model_type='virtual')
 
 pos_x, pos_y = generate_positions(30)
-lgn.add_nodes(N=30, pop_name='tONOFF', ei='e', location='LGN',
+lgn.add_nodes(N=30, model_name='tONOFF', ei='e', location='LGN',
               x=pos_x, y=pos_y,
               model_type='virtual')
 
 
 
 
-lgn.add_edges(source=lgn.nodes(), target=net.nodes(pop_name='LIF_exc'),
+lgn.add_edges(source=lgn.nodes(), target=net.nodes(model_name='LIF_exc'),
               iterator='all_to_one',
               connection_rule=select_source_cells,
               connection_params={'n_syns': 10},
@@ -113,7 +113,7 @@ lgn.add_edges(source=lgn.nodes(), target=net.nodes(pop_name='LIF_exc'),
               delay=2.0,
               dynamics_params='instanteneousExc.json')
 
-lgn.add_edges(source=lgn.nodes(), target=net.nodes(pop_name='LIF_inh'),
+lgn.add_edges(source=lgn.nodes(), target=net.nodes(model_name='LIF_inh'),
               iterator='all_to_one',
               connection_rule=select_source_cells,
               connection_params={'n_syns': 10},
@@ -127,16 +127,16 @@ lgn.save(output_dir='network')
 
 
 tw = NetworkBuilder("tw")
-tw.add_nodes(N=30, pop_name='TW', ei='e', location='TW', model_type='virtual')
+tw.add_nodes(N=30, model_name='TW', ei='e', location='TW', model_type='virtual')
 
-tw.add_edges(source=tw.nodes(), target=net.nodes(pop_name='LIF_exc'),
+tw.add_edges(source=tw.nodes(), target=net.nodes(model_name='LIF_exc'),
              connection_rule=5,
              syn_weight=0.01,
              weight_function='wmax',
              delay=2.0,
              dynamics_params='instanteneousExc.json')
 
-tw.add_edges(source=tw.nodes(), target=net.nodes(pop_name='LIF_inh'),
+tw.add_edges(source=tw.nodes(), target=net.nodes(model_name='LIF_inh'),
              connection_rule=5,
              syn_weight=0.02,
              weight_function='wmax',

--- a/examples/300_intfire/network/lgn_node_types.csv
+++ b/examples/300_intfire/network/lgn_node_types.csv
@@ -1,4 +1,4 @@
-node_type_id model_type ei location pop_name
+node_type_id model_type ei location model_name
 100 virtual e LGN tON
 101 virtual e LGN tOFF
 102 virtual e LGN tONOFF

--- a/examples/300_intfire/network/lgn_v1_edge_types.csv
+++ b/examples/300_intfire/network/lgn_v1_edge_types.csv
@@ -1,3 +1,3 @@
 edge_type_id target_query source_query delay weight_function syn_weight dynamics_params
-100 pop_name=='LIF_exc' * 2.0 wmax 0.0045 instanteneousExc.json
-101 pop_name=='LIF_inh' * 2.0 wmax 0.0015 instanteneousExc.json
+100 model_name=='LIF_exc' * 2.0 wmax 0.0045 instanteneousExc.json
+101 model_name=='LIF_inh' * 2.0 wmax 0.0015 instanteneousExc.json

--- a/examples/300_intfire/network/tw_node_types.csv
+++ b/examples/300_intfire/network/tw_node_types.csv
@@ -1,2 +1,2 @@
-node_type_id model_type ei location pop_name
+node_type_id model_type ei location model_name
 100 virtual e TW TW

--- a/examples/300_intfire/network/tw_v1_edge_types.csv
+++ b/examples/300_intfire/network/tw_v1_edge_types.csv
@@ -1,3 +1,3 @@
 edge_type_id target_query source_query delay weight_function syn_weight dynamics_params
-100 pop_name=='LIF_exc' * 2.0 wmax 0.01 instanteneousExc.json
-101 pop_name=='LIF_inh' * 2.0 wmax 0.02 instanteneousExc.json
+100 model_name=='LIF_exc' * 2.0 wmax 0.01 instanteneousExc.json
+101 model_name=='LIF_inh' * 2.0 wmax 0.02 instanteneousExc.json

--- a/examples/300_intfire/network/v1_node_types.csv
+++ b/examples/300_intfire/network/v1_node_types.csv
@@ -1,3 +1,3 @@
-node_type_id ei pop_name location model_template model_type dynamics_params
+node_type_id ei model_name location model_template model_type dynamics_params
 100 e LIF_exc VisL4 nrn:IntFire1 point_process IntFire1_exc_1.json
 101 i LIF_inh VisL4 nrn:IntFire1 point_process IntFire1_inh_1.json

--- a/examples/300_intfire/network/v1_v1_edge_types.csv
+++ b/examples/300_intfire/network/v1_v1_edge_types.csv
@@ -1,5 +1,5 @@
 edge_type_id target_query source_query delay weight_function syn_weight dynamics_params
 100 model_type=='point_process'&ei=='i' ei=='i' 2.0 wmax 0.01 instanteneousInh.json
 101 model_type=='point_process'&ei=='e' ei=='i' 2.0 wmax 0.15 instanteneousInh.json
-102 pop_name=='LIF_inh' ei=='e' 2.0 wmax 0.3 instanteneousExc.json
-103 pop_name=='LIF_exc' ei=='e' 2.0 wmax 0.002 instanteneousExc.json
+102 model_name=='LIF_inh' ei=='e' 2.0 wmax 0.3 instanteneousExc.json
+103 model_name=='LIF_exc' ei=='e' 2.0 wmax 0.002 instanteneousExc.json

--- a/examples/300_intfire/plot_spikes.py
+++ b/examples/300_intfire/plot_spikes.py
@@ -1,3 +1,3 @@
 from bmtk.analyzer.visualization.spikes import plot_spikes
 
-plot_spikes('network/v1_nodes.h5', 'network/v1_node_types.csv', 'output/spikes.h5', group_key='pop_name')
+plot_spikes('network/v1_nodes.h5', 'network/v1_node_types.csv', 'output/spikes.h5', group_key='model_name')


### PR DESCRIPTION
Per issue #44, I updated the 300_intfire example so that all examples use "model_name" instead of "pop_name". This is an optional attribute that shouldn't have an effect on the simulation, but it's best to still remain consistent.