### PR TITLE
Fixing 5_cells_iclamp example to use NeuroML files

### DIFF
--- a/examples/5_cells_iclamp/build_network.py
+++ b/examples/5_cells_iclamp/build_network.py
@@ -5,28 +5,23 @@ from bmtk.builder import NetworkBuilder
 cell_models = [
     {
         'model_name': 'Scnn1a', 'x': [0.0], 'y': [0.0], 'z': [0.0], 'ei': 'e', 'morphology': 'Scnn1a_473845048_m',
-        'model_template': 'ctdb:Biophys1.hoc',
-        'dynamics_params': '472363762_fit.json',
+        'model_template': 'nml:Cell_472363762.cell.nml'
     },
     {
         'model_name': 'Rorb', 'x': [200.0], 'y': [0.0], 'z': [0.0], 'ei': 'e', 'morphology': 'Rorb_325404214_m',
-        'model_template': 'ctdb:Biophys1.hoc',
-        'dynamics_params': '473863510_fit.json',
+        'model_template': 'nml:Cell_473863510.cell.nml'
     },
     {
         'model_name': 'Nr5a1', 'x': [-200.0], 'y': [0.0], 'z': [0.0], 'ei': 'e', 'morphology': 'Nr5a1_471087815_m',
-        'model_template': 'ctdb:Biophys1.hoc',
-        'dynamics_params': '473863035_fit.json',
+        'model_template': 'nml:Cell_473863035.cell.nml'
     },
     {
         'model_name': 'PV1', 'x': [0.0], 'y': [200.0], 'z': [0.0], 'ei': 'i', 'morphology': 'Pvalb_470522102_m',
-        'model_template': 'ctdb:Biophys1.hoc',
-        'dynamics_params': '472912177_fit.json',
+        'model_template': 'nml:Cell_472912177.cell.nml'
     },
     {
         'model_name': 'PV2', 'x': [0.0], 'y': [-200.0], 'z': [0.0], 'ei': 'i', 'morphology': 'Pvalb_469628681_m',
-        'model_template': 'ctdb:Biophys1.hoc',
-        'dynamics_params': '473862421_fit.json',
+        'model_template': 'nml:Cell_473862421.cell.nml'
     }
 ]
 

--- a/examples/5_cells_iclamp/circuit_config.json
+++ b/examples/5_cells_iclamp/circuit_config.json
@@ -8,7 +8,7 @@
   "components": {
     "morphologies_dir": "$COMPONENT_DIR/morphologies",
     "mechanisms_dir":"$COMPONENT_DIR/mechanisms",
-    "biophysical_neuron_models_dir": "$COMPONENT_DIR/biophysical_neuron_templates/json"
+    "biophysical_neuron_models_dir": "$COMPONENT_DIR/biophysical_neuron_templates/nml"
   },
 
   "networks": {

--- a/examples/5_cells_iclamp/network/biophysical_node_types.csv
+++ b/examples/5_cells_iclamp/network/biophysical_node_types.csv
@@ -1,6 +1,6 @@
-node_type_id dynamics_params model_processing model_type model_template morphology ei model_name
-104 473862421_fit.json aibs_perisomatic biophysical ctdb:Biophys1.hoc Pvalb_469628681_m i PV2
-100 472363762_fit.json aibs_perisomatic biophysical ctdb:Biophys1.hoc Scnn1a_473845048_m e Scnn1a
-101 473863510_fit.json aibs_perisomatic biophysical ctdb:Biophys1.hoc Rorb_325404214_m e Rorb
-102 473863035_fit.json aibs_perisomatic biophysical ctdb:Biophys1.hoc Nr5a1_471087815_m e Nr5a1
-103 472912177_fit.json aibs_perisomatic biophysical ctdb:Biophys1.hoc Pvalb_470522102_m i PV1
+node_type_id model_processing model_type model_template morphology ei model_name
+104 aibs_perisomatic biophysical nml:Cell_473862421.cell.nml Pvalb_469628681_m i PV2
+100 aibs_perisomatic biophysical nml:Cell_472363762.cell.nml Scnn1a_473845048_m e Scnn1a
+101 aibs_perisomatic biophysical nml:Cell_473863510.cell.nml Rorb_325404214_m e Rorb
+102 aibs_perisomatic biophysical nml:Cell_473863035.cell.nml Nr5a1_471087815_m e Nr5a1
+103 aibs_perisomatic biophysical nml:Cell_472912177.cell.nml Pvalb_470522102_m i PV1


### PR DESCRIPTION
I changed the 5_cells_iclamp example to use NeuroML files instead of the AIBS json based files. Otherwise the circuit and the simulations should be exactly the same.