### PR TITLE
Changes needed to run 300_pointneurons example with PyNN

### DIFF
--- a/examples/300_pointneurons/circuit_config.json
+++ b/examples/300_pointneurons/circuit_config.json
@@ -32,6 +32,7 @@
         "edge_types_file": "$NETWORK_DIR/external_internal_edge_types.csv"
       }
     ]
+  },
 
-  }
+  "target_simulator": "NEST"
 }

--- a/examples/300_pointneurons/network/external_internal_edge_types.csv
+++ b/examples/300_pointneurons/network/external_internal_edge_types.csv
@@ -1,3 +1,3 @@
 edge_type_id target_query source_query delay dynamics_params model_template
-100 ei=='e' * 2.0 ExcToExc.json static_synapse
-101 ei=='i' * 2.0 ExcToInh.json static_synapse
+100 ei=='e' * 2.0 ExcToExc.json nest:static_synapse
+101 ei=='i' * 2.0 ExcToInh.json nest:static_synapse

--- a/examples/300_pointneurons/network/internal_internal_edge_types.csv
+++ b/examples/300_pointneurons/network/internal_internal_edge_types.csv
@@ -1,5 +1,5 @@
 edge_type_id target_query source_query delay dynamics_params model_template
-100 ei=='e' ei=='e' 2.0 ExcToExc.json static_synapse
-101 ei=='i' ei=='e' 2.0 ExcToInh.json static_synapse
-102 ei=='e' ei=='i' 2.0 InhToExc.json static_synapse
-103 ei=='i' ei=='i' 2.0 InhToInh.json static_synapse
+100 ei=='e' ei=='e' 2.0 ExcToExc.json nest:static_synapse
+101 ei=='i' ei=='e' 2.0 ExcToInh.json nest:static_synapse
+102 ei=='e' ei=='i' 2.0 InhToExc.json nest:static_synapse
+103 ei=='i' ei=='i' 2.0 InhToInh.json nest:static_synapse

--- a/examples/300_pointneurons/node_sets.json
+++ b/examples/300_pointneurons/node_sets.json
@@ -3,5 +3,8 @@
     "population": "external"
   },
 
-  "recorded_cells": [0, 80, 160, 240, 270]
+  "recorded_cells": {
+      "population": "internal",
+      "node_id": [0, 80, 160, 240, 270]
+  }
 }

--- a/examples/300_pointneurons/run_PyNN.py
+++ b/examples/300_pointneurons/run_PyNN.py
@@ -1,0 +1,7 @@
+from pyNN.serialization import import_from_sonata, load_sonata_simulation_plan
+import pyNN.nest as sim
+
+simulation_plan = load_sonata_simulation_plan("simulation_config.json")
+simulation_plan.setup(sim)
+net = import_from_sonata("circuit_config.json", sim)
+simulation_plan.execute(net)


### PR DESCRIPTION
This is not for merging immediately, as these changes make it incompatible with the current development version of bmtk.

The main changes are:
- put "target_simulator" in "circuit_config.json" instead of "simulation_config.json" (this is also more compatible with the current version of the spec)
- add a prefix "nest:" to "static_synapse" in the "edge_types.csv" files. This is not absolutely essential, but makes the edge_types files more consistent with the node_types files.
- specify the population name in "node_sets.json" - this I think is required by the spec.
