### PR TITLE
fix group indices build

### DIFF
--- a/src/pysonata/sonata/io/population.py
+++ b/src/pysonata/sonata/io/population.py
@@ -122,7 +122,7 @@ class Population(object):
         else:
             tmp_index = pd.DataFrame()
             # TODO: Need to check the memory overhead, especially for edges. See if an iterative search is just as fast
-            tmp_index['grp_id'] = pd.Series(self._group_id_ds, dtype=self._group_id_ds.dtype)
+            tmp_index['grp_id'] = pd.Series(self._group_id_ds[()], dtype=self._group_id_ds.dtype)
             tmp_index['row_indx'] = pd.Series(range_itr(self._nrows), dtype=np.uint32)
             if build_cache:
                 # save all indicies as arrays


### PR DESCRIPTION
Without this fix I keep receiving this error.
```
File "/home/sanin/workspace/project/sonata_api.py", line 113, in <module>
  '/home/sanin/workspace/project/tests/reduced_output'
File "/home/sanin/workspace/project/sonata_api.py", line 93, in reduce
  for node in group:
File "/home/sanin/workspace/project/venv/lib/python3.6/site-packages/sonata/io/group.py", line 307, in __iter__
  self.build_indicies()
File "/home/sanin/workspace/project/venv/lib/python3.6/site-packages/sonata/io/group.py", line 177, in build_indicies
  self._parent_indicies = self._parent.group_indicies(self.group_id, build_cache=True)
File "/home/sanin/workspace/project/venv/lib/python3.6/site-packages/sonata/io/population.py", line 125, in group_indicies
  tmp_index['grp_id'] = pd.Series(self._group_id_ds, dtype=self._group_id_ds.dtype)
File "/home/sanin/workspace/project/venv/lib/python3.6/site-packages/pandas/core/series.py", line 311, in __init__
  data = sanitize_array(data, index, dtype, copy, raise_cast_failure=True)
File "/home/sanin/workspace/project/venv/lib/python3.6/site-packages/pandas/core/internals/construction.py", line 696, in sanitize_array
  subarr = _try_cast(data, dtype, copy, raise_cast_failure)
File "/home/sanin/workspace/project/venv/lib/python3.6/site-packages/pandas/core/internals/construction.py", line 782, in _try_cast
  subarr = maybe_cast_to_integer_array(arr, dtype)
File "/home/sanin/workspace/project/venv/lib/python3.6/site-packages/pandas/core/dtypes/cast.py", line 1353, in maybe_cast_to_integer_array
  casted = arr.astype(dtype, copy=copy)
TypeError: astype() got an unexpected keyword argument 'copy'
```
`pd.Series` expects an iterable with `astype` method that supports an arg `copy`. h5py dataset has `astype` but without the arg `copy` hence the error.

@pgleeson or @kaeldai please merge.