### PR TITLE
Fix (again) incorrect model_template in 300_pointneurons example

### DIFF
--- a/examples/300_pointneurons/network/external_internal_edge_types.csv
+++ b/examples/300_pointneurons/network/external_internal_edge_types.csv
@@ -1,3 +1,3 @@
 edge_type_id target_query source_query dynamics_params model_template
-100 ei=='e' * ExcToExc.json static_synapse
-101 ei=='i' * ExcToInh.json static_synapse
+100 ei=='e' * ExcToExc.json nest:static_synapse
+101 ei=='i' * ExcToInh.json nest:static_synapse

--- a/examples/300_pointneurons/network/internal_internal_edge_types.csv
+++ b/examples/300_pointneurons/network/internal_internal_edge_types.csv
@@ -1,5 +1,5 @@
 edge_type_id target_query source_query delay dynamics_params model_template
-100 ei=='e' ei=='e' 2.0 ExcToExc.json static_synapse
-101 ei=='i' ei=='e' 2.0 ExcToInh.json static_synapse
-102 ei=='e' ei=='i' 2.0 InhToExc.json static_synapse
-103 ei=='i' ei=='i' 2.0 InhToInh.json static_synapse
+100 ei=='e' ei=='e' 2.0 ExcToExc.json nest:static_synapse
+101 ei=='i' ei=='e' 2.0 ExcToInh.json nest:static_synapse
+102 ei=='e' ei=='i' 2.0 InhToExc.json nest:static_synapse
+103 ei=='i' ei=='i' 2.0 InhToInh.json nest:static_synapse


### PR DESCRIPTION
 According to the [spec](https://github.com/AllenInstitute/sonata/blob/master/docs/SONATA_DEVELOPER_GUIDE.md#nodes---required-attributes), model_template "uses a colon-separated string-pair with the following syntax: schema:resource"

In the example, the schema "nest" is needed to correctly identify the synapse model.

This was fixed previously, but there has been a regression at some point.